### PR TITLE
fix: allow 2-ariety function as preload function

### DIFF
--- a/lib/ecto/query/builder/preload.ex
+++ b/lib/ecto/query/builder/preload.ex
@@ -309,6 +309,7 @@ defmodule Ecto.Query.Builder.Preload do
 
   defp assert_query_or_fun!(%Ecto.Query{}, _key), do: :ok
   defp assert_query_or_fun!(fun, _key) when is_function(fun, 1), do: :ok
+  defp assert_query_or_fun!(fun, _key) when is_function(fun, 2), do: :ok
 
   defp assert_query_or_fun!(other, key) do
     raise ArgumentError,


### PR DESCRIPTION
As described in the error message, "Preloads can be a query, a function expecting one or two arguments".

Right now we are now allowing 2-ariety functions receiving `ids` and `assoc` as arguments.